### PR TITLE
try to fix the push registration crash

### DIFF
--- a/ios/Shared/Backend/HomeCommunication.swift
+++ b/ios/Shared/Backend/HomeCommunication.swift
@@ -81,7 +81,7 @@ struct RemoteHome: Home {
     private func url(_ route: Route, _ action: Action, _ path: String? = nil) -> URL {
         let url = (route == .external ? externalHost : localNetworkHost).appendingPathComponent(action.rawValue)
         if let path {
-            return url.appendingPathComponent(path)
+            return url.appendingPathComponent("\(path)")
         } else {
             return url
         }


### PR DESCRIPTION
try to prevent the `URL.appendingPathComponent` crash by escaping the `deviceToken` string on Push Notification registration.